### PR TITLE
Fixed the issue where the error message would be displayed twice

### DIFF
--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -28,10 +28,11 @@ func NewCmdLogs(streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewLogsOptions(streams)
 
 	cmd := &cobra.Command{
-		Use:          "logs",
-		Short:        "Selecting a Pod with the fuzzy finder and view the log",
-		Example:      example,
-		SilenceUsage: true,
+		Use:           "logs",
+		Short:         "Selecting a Pod with the fuzzy finder and view the log",
+		Example:       example,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.Complete(c, args); err != nil {
 				return err


### PR DESCRIPTION
Fixed the issue where the error message would be displayed twice

```console
$ kubectl fzf logs -f
Error: failed to fuzzyfinder execute: abort
failed to fuzzyfinder execute: abort
```